### PR TITLE
bump array-normalize 1.1.4 - preserve gaps in data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,9 +82,9 @@
       "dev": true
     },
     "array-normalize": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/array-normalize/-/array-normalize-1.1.3.tgz",
-      "integrity": "sha1-c/uDf0gW7BkVHTxejYU6RZDOAb0=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array-normalize/-/array-normalize-1.1.4.tgz",
+      "integrity": "sha512-fCp0wKFLjvSPmCn4F5Tiw4M3lpMZoHlCjfcs7nNzuj3vqQQ1/a8cgB9DXcpDSn18c+coLnaW7rqfcYCvKbyJXg==",
       "requires": {
         "array-bounds": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/dy/regl-line2d#readme",
   "dependencies": {
     "array-bounds": "^1.0.1",
-    "array-normalize": "^1.1.3",
+    "array-normalize": "^1.1.4",
     "bubleify": "^1.2.0",
     "color-normalize": "^1.5.0",
     "earcut": "^2.1.5",


### PR DESCRIPTION
Fix https://github.com/gl-vis/regl-line2d/issues/43 by bumping `array-normalize` to version 1.1.4

@dy 
cc: @etpinard 
