### PR TITLE
Bump to-float32 package

### DIFF
--- a/index.js
+++ b/index.js
@@ -623,8 +623,10 @@ Line2D.prototype.update = function (options) {
 				positionData[count*2 + 5] = npos[count*2 - 1]
 			}
 
-			state.positionBuffer(float32(positionData))
-			state.positionFractBuffer(fract32(positionData))
+			var float_data = float32(positionData)
+			state.positionBuffer(float_data)
+			var frac_data = fract32(positionData, float_data)
+			state.positionFractBuffer(frac_data)
 		}
 
 		if (o.range) {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "object-assign": "^4.1.1",
     "parse-rect": "^1.2.0",
     "pick-by-alias": "^1.2.0",
-    "to-float32": "^1.0.1",
+    "to-float32": "^1.1.0",
     "array-find-index": "^1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrades to-float32 package and uses the new version to improve the performance when drawing.

You can see the to-float32 package changes [here](https://github.com/dy/to-float32/pull/1)

Other packages PRs: [here](https://github.com/gl-vis/regl-error2d/pull/9), [here](https://github.com/gl-vis/regl-scatter2d/pull/31)

@archmoj

cc: @alexcjohnson 